### PR TITLE
Add README, CODEOWNERS for rufio

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+/.github/settings.yml @chrisdoherty4 @displague @jacobweinstock
+/.github/CODEOWNERS @chrisdoherty4 @displague @jacobweinstock

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,30 @@
+# Collaborators: give specific users access to this repository.
+# See https://docs.github.com/en/rest/reference/repos#add-a-repository-collaborator for available options
+collaborators:
+  # Maintainers, should also be added to the .github/CODEOWNERS file as owners of this settings.yml file.
+  - username: chrisdoherty4
+    permission: maintain
+  - username: displague
+    permission: maintain
+  - username: jacobweinstock
+    permission: maintain
+  # Approvers
+  - username: joelrebel
+    permission: push
+  - username: micahhausler
+    permission: push
+  - username: nshalman
+    permission: push
+  # Reviewers
+  - username: mmlb
+    permission: triage
+  - username: abhay-krishna
+    permission: triage
+
+  # Note: `permission` is only valid on organization-owned repositories.
+  # The permission to grant the collaborator. Can be one of:
+  # * `pull` - can pull, but not push to or administer this repository.
+  # * `push` - can pull and push, but not administer this repository.
+  # * `admin` - can pull, push and administer this repository.
+  # * `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
+  # * `triage` - Recommended for contributors who need to proactively manage issues and pull requests without write access.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Refer to our [Code of Conduct](https://github.com/tinkerbell/.github/blob/main/CODE_OF_CONDUCT.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributor Guide
+
+Welcome to Rufio! We are really excited to have you.
+Please use the following guide on your contributing journey.
+Thanks for contributing!
+
+## Table of Contents
+
+- [Context](#Context)
+- [Prerequisites](#Prerequisites)
+  - [DCO Sign Off](#DCO-Sign-Off)
+  - [Code of Conduct](#Code-of-Conduct)
+  - [Setting up your development environment](#Setting-up-your-development-environment)
+- [Pull Requests](#Pull-Requests)
+  - [Branching strategy](#Branching-strategy)
+  - [Quality](#Quality)
+    - [CI](#CI)
+    - [Code coverage](#Code-coverage)
+  - [Pre PR Checklist](#Pre-PR-Checklist)
+
+---
+
+## Context
+
+
+Rufio is a Kubernetes controller for managing baseboard management state and actions.It is part of the [Tinkerbell stack](https://tinkerbell.org) and provides the glue for machine provisioning by enabling machine restarts and setting next boot devices.
+
+## Prerequisites
+
+### DCO Sign Off
+
+Please read and understand the DCO found [here](docs/DCO.md).
+
+### Code of Conduct
+
+Please read and understand the code of conduct found [here](https://github.com/tinkerbell/rufio/blob/main/CODE_OF_CONDUCT.md).
+
+### Setting up your development environment
+
+1. Install Go
+
+   Rufio requires [Go 1.17](https://golang.org/dl/) or later.
+
+1. Install Docker
+
+   Rufio uses Docker for protocol buffer code generation, container image builds and for the Ruby client example.
+   Most versions of Docker will work.
+
+> The items below are nice to haves, but not hard requirements for development
+
+1. Install golangci-lint
+
+   [golangci-lint](https://golangci-lint.run/usage/install/) is used in CI for lint checking and should be run locally before creating a PR.
+
+## Pull Requests
+
+### Branching strategy
+
+Rufio uses a fork and pull request model.
+See this [doc](https://guides.github.com/activities/forking/) for more details.
+
+### Quality
+
+#### CI
+
+Rufio uses GitHub Actions for CI.
+The workflow is found in [.github/workflows/ci.yaml](.github/workflows/ci.yaml).
+It is run for each commit and PR.
+The container image building only happens once a PR is merged into the main line.
+
+#### Code coverage
+
+Rufio does run code coverage with each PR.
+Coverage thresholds are not currently enforced.
+It is always nice and very welcomed to add tests and keep or increase the code coverage percentage.
+
+### Pre PR Checklist
+
+This checklist is a helper to make sure there's no gotchas that come up when you submit a PR.
+
+- [ ] You've reviewed the [code of conduct](#Code-of-Conduct)
+- [ ] All commits are DCO signed off
+- [ ] Code is [formatted and linted](#Linting)
+- [ ] Code [builds](#Building) successfully
+- [ ] All tests are [passing](#Unit-testing)
+- [ ] Code coverage [percentage](#Code-coverage). (main line is the base with which to compare)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Rufio
+
+![For each commit and PR](https://github.com/tinkerbell/rufio/workflows/For%20each%20commit%20and%20PR/badge.svg)
+![stability](https://img.shields.io/badge/Stability-Experimental-red.svg)
+
+> This repository is [Experimental](https://github.com/packethost/standards/blob/main/experimental-statement.md) meaning that it's based on untested ideas or techniques and not yet established or finalized or involves a radically new and innovative style!
+> This means that support is best effort (at best!) and we strongly encourage you to NOT use this in production.
+
+## Description
+
+**R**ufio
+**U**ses
+**F**ancy
+**I**PMI
+**O**perations
+
+Rufio is a Kubernetes controller for managing baseboard management state and actions.
+
+Goals:
+
+* Declaratively enforce and ensure BMC state such as:
+  * Power state
+  * Persistent boot order
+  * NTP/LDAP/TLS Cert configuration (probably future scope)
+ * Declaratively enact actions such as:
+   *  Power reset
+   * Configure ephemeral boot order
+* Report state such as:
+  * Firmware version
+  * Other Redfish/Swordfish machine metadata
+
+Implementation
+* Kubernetes-based controller
+* AuthN/Z is enforced with Kubernetes Authentication/RBAC
+* BMC authentication is managed with Kubernetes Secrets
+
+## Contributing
+
+See the contributors guide [here](CONTRIBUTING.md).
+
+## Website
+
+For complete documentation, please visit the Tinkerbell project hosted at [tinkerbell.org](https://tinkerbell.org).


### PR DESCRIPTION
Signed-off-by: Micah Hausler <mhausler@amazon.com>

## Description

Rufio is a Kubernetes controller for managing baseboard management state and actions. I copied maintainers, approvers, and reviewers from PBnJ.

## Why is this needed

So the right folks can review and approve PRs and issues in this repo 

## Responding

Can the following folks chime in if they're up for participating in this repo?

- [x] @chrisdoherty4
- [x] @displague 
- [x] @jacobweinstock 
- [x] @joelrebel
- [x] @micahhausler 
- [x] @nshalman 
- [x] @mmlb 
- [x] @abhay-krishna
- [ ] @Raj-Dharwadkar 