### PR TITLE
Adding ipmi port to BaseboardManagement type

### DIFF
--- a/api/v1alpha1/baseboardmanagement_types.go
+++ b/api/v1alpha1/baseboardmanagement_types.go
@@ -64,9 +64,9 @@ type Connection struct {
 	// +kubebuilder:validation:MinLength=1
 	Host string `json:"host"`
 
-	// Port is the IPMI port of the BaseboardManagement.
-	// +kubebuilder:validation:MinLength=1
-	Port string `json:"port"`
+	// Port is the port number for connecting with the BaseboardManagement.
+	// +kubebuilder:default:=623
+	Port int `json:"port"`
 
 	// AuthSecretRef is the SecretReference that contains authentication information of the BaseboardManagement.
 	// The Secret must contain username and password keys.

--- a/api/v1alpha1/baseboardmanagement_types.go
+++ b/api/v1alpha1/baseboardmanagement_types.go
@@ -64,6 +64,10 @@ type Connection struct {
 	// +kubebuilder:validation:MinLength=1
 	Host string `json:"host"`
 
+	// Port is the IPMI port of the BaseboardManagement.
+	// +kubebuilder:validation:MinLength=1
+	Port string `json:"port"`
+
 	// AuthSecretRef is the SecretReference that contains authentication information of the BaseboardManagement.
 	// The Secret must contain username and password keys.
 	AuthSecretRef corev1.SecretReference `json:"authSecretRef"`

--- a/config/crd/bases/bmc.tinkerbell.org_baseboardmanagements.yaml
+++ b/config/crd/bases/bmc.tinkerbell.org_baseboardmanagements.yaml
@@ -65,10 +65,15 @@ spec:
                   insecureTLS:
                     description: InsecureTLS specifies trusted TLS connections.
                     type: boolean
+                  port:
+                    description: Port is the IPMI port of the BaseboardManagement.
+                    minLength: 1
+                    type: string
                 required:
                 - authSecretRef
                 - host
                 - insecureTLS
+                - port
                 type: object
               power:
                 description: Power is the desired power state of the BaseboardManagement.

--- a/config/crd/bases/bmc.tinkerbell.org_baseboardmanagements.yaml
+++ b/config/crd/bases/bmc.tinkerbell.org_baseboardmanagements.yaml
@@ -66,9 +66,9 @@ spec:
                     description: InsecureTLS specifies trusted TLS connections.
                     type: boolean
                   port:
-                    description: Port is the IPMI port of the BaseboardManagement.
-                    minLength: 1
-                    type: string
+                    default: 623
+                    description: Port is the port number for connecting with the BaseboardManagement.
+                    type: integer
                 required:
                 - authSecretRef
                 - host

--- a/config/samples/bmc_v1alpha1_baseboardmanagement.yaml
+++ b/config/samples/bmc_v1alpha1_baseboardmanagement.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   connection:
     host: 0.0.0.0
+    port: 623
     authSecretRef:
       name: bm-auth
       namespace: sample

--- a/controllers/baseboardmanagement_controller.go
+++ b/controllers/baseboardmanagement_controller.go
@@ -114,9 +114,8 @@ func (r *BaseboardManagementReconciler) reconcile(ctx context.Context, bm *bmcv1
 		return ctrl.Result{Requeue: true}, fmt.Errorf("resolving BaseboardManagement %s/%s SecretReference: %v", bm.Namespace, bm.Name, err)
 	}
 
-	// TODO (pokearu): Remove port hardcoding
 	// Initializing BMC Client
-	bmcClient, err := r.bmcClientFactory(ctx, bm.Spec.Connection.Host, "623", username, password)
+	bmcClient, err := r.bmcClientFactory(ctx, bm.Spec.Connection.Host, bm.Spec.Connection.Port, username, password)
 	if err != nil {
 		logger.Error(err, "BMC connection failed", "host", bm.Spec.Connection.Host)
 		result, setConditionErr := r.setCondition(ctx, bm, bmPatch, bmcv1alpha1.ConnectionError, err.Error())

--- a/controllers/baseboardmanagement_controller.go
+++ b/controllers/baseboardmanagement_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -115,7 +116,7 @@ func (r *BaseboardManagementReconciler) reconcile(ctx context.Context, bm *bmcv1
 	}
 
 	// Initializing BMC Client
-	bmcClient, err := r.bmcClientFactory(ctx, bm.Spec.Connection.Host, bm.Spec.Connection.Port, username, password)
+	bmcClient, err := r.bmcClientFactory(ctx, bm.Spec.Connection.Host, strconv.Itoa(bm.Spec.Connection.Port), username, password)
 	if err != nil {
 		logger.Error(err, "BMC connection failed", "host", bm.Spec.Connection.Host)
 		result, setConditionErr := r.setCondition(ctx, bm, bmPatch, bmcv1alpha1.ConnectionError, err.Error())

--- a/controllers/baseboardmanagement_controller_test.go
+++ b/controllers/baseboardmanagement_controller_test.go
@@ -221,6 +221,7 @@ func getBaseboardManagement() *bmcv1alpha1.BaseboardManagement {
 		Spec: bmcv1alpha1.BaseboardManagementSpec{
 			Connection: bmcv1alpha1.Connection{
 				Host: "0.0.0.0",
+				Port: "623",
 				AuthSecretRef: corev1.SecretReference{
 					Name:      "test-bm-auth",
 					Namespace: "test-namespace",

--- a/controllers/baseboardmanagement_controller_test.go
+++ b/controllers/baseboardmanagement_controller_test.go
@@ -221,7 +221,7 @@ func getBaseboardManagement() *bmcv1alpha1.BaseboardManagement {
 		Spec: bmcv1alpha1.BaseboardManagementSpec{
 			Connection: bmcv1alpha1.Connection{
 				Host: "0.0.0.0",
-				Port: "623",
+				Port: 623,
 				AuthSecretRef: corev1.SecretReference{
 					Name:      "test-bm-auth",
 					Namespace: "test-namespace",


### PR DESCRIPTION
Signed-off-by: Aravind Ramalingam <ramaliar@amazon.com>

## Description
Added Port to `BaseboardManagement.Spec.Connection`. Port represents the IPMI port of the BMC.

## Why is this needed
Removes port hardcoding to default IPMI UDP port `623`