### PR TITLE
Adding logic to Dockerfile to build ipmitool into the controller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,47 @@ COPY ./ ./
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM alpine:3.8
+
+ARG IPMITOOL_REPO=https://github.com/ipmitool/ipmitool.git
+ARG IPMITOOL_COMMIT=IPMITOOL_1_8_18
+
+# Install dependencies for ipmitool
+WORKDIR /tmp
+RUN apk add --update --upgrade --no-cache --virtual build-deps \
+        alpine-sdk=1.0-r0 \
+        autoconf=2.69-r2 \
+        automake=1.16.1-r0 \
+        git=2.18.4-r0 \
+        libtool=2.4.6-r5 \
+        ncurses-dev=6.1_p20180818-r1 \
+        openssl-dev=1.0.2u-r0 \
+        readline-dev=7.0.003-r0 \
+    && apk add --update --upgrade --no-cache --virtual run-deps \
+	    ca-certificates=20191127-r2 \
+        libcrypto1.0=1.0.2u-r0 \
+        musl=1.1.19-r11 \
+        readline=7.0.003-r0 \
+    && git clone -b master ${IPMITOOL_REPO}
+
+# Install ipmitool
+WORKDIR /tmp/ipmitool
+RUN git checkout ${IPMITOOL_COMMIT} \
+    && ./bootstrap \
+    && ./configure \
+        --prefix=/usr/local \
+        --enable-ipmievd \
+        --enable-ipmishell \
+        --enable-intf-lan \
+        --enable-intf-lanplus \
+        --enable-intf-open \
+    && make \
+    && make install \
+    && apk del build-deps
+
+WORKDIR /tmp
+RUN rm -rf /tmp/ipmitool
+
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,46 +15,9 @@ COPY ./ ./
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
-FROM alpine:3.8
+FROM alpine:3.15
 
-ARG IPMITOOL_REPO=https://github.com/ipmitool/ipmitool.git
-ARG IPMITOOL_COMMIT=IPMITOOL_1_8_18
-
-# Install dependencies for ipmitool
-WORKDIR /tmp
-RUN apk add --update --upgrade --no-cache --virtual build-deps \
-        alpine-sdk=1.0-r0 \
-        autoconf=2.69-r2 \
-        automake=1.16.1-r0 \
-        git=2.18.4-r0 \
-        libtool=2.4.6-r5 \
-        ncurses-dev=6.1_p20180818-r1 \
-        openssl-dev=1.0.2u-r0 \
-        readline-dev=7.0.003-r0 \
-    && apk add --update --upgrade --no-cache --virtual run-deps \
-	    ca-certificates=20191127-r2 \
-        libcrypto1.0=1.0.2u-r0 \
-        musl=1.1.19-r11 \
-        readline=7.0.003-r0 \
-    && git clone -b master ${IPMITOOL_REPO}
-
-# Install ipmitool
-WORKDIR /tmp/ipmitool
-RUN git checkout ${IPMITOOL_COMMIT} \
-    && ./bootstrap \
-    && ./configure \
-        --prefix=/usr/local \
-        --enable-ipmievd \
-        --enable-ipmishell \
-        --enable-intf-lan \
-        --enable-intf-lanplus \
-        --enable-intf-open \
-    && make \
-    && make install \
-    && apk del build-deps
-
-WORKDIR /tmp
-RUN rm -rf /tmp/ipmitool
+RUN apk add --upgrade ipmitool=1.8.18-r10
 
 WORKDIR /
 COPY --from=builder /workspace/manager .


### PR DESCRIPTION
## Description
Adding steps to install ipmitool binary on the controller image. These changes are based on PBNJ's [Dockerfile](https://github.com/tinkerbell/pbnj/blob/main/Dockerfile#L13L46).

## Why is this needed
`ipmitool` binary is required by bmclib during runtime. The `ipmitool` provider on bmclib uses ipmitool binary for actions.

Fixes: #

## How Has This Been Tested?
`make docker-build`
