### PR TITLE
BaseboardManagement controller to readonly

### DIFF
--- a/api/v1alpha1/baseboardmanagement_types.go
+++ b/api/v1alpha1/baseboardmanagement_types.go
@@ -56,10 +56,6 @@ const (
 	ConditionFalse ConditionStatus = "False"
 )
 
-// PausedAnnotation is an annotation that can be applied to BaseboardManagement
-// object to prevent a controller from processing a resource.
-const PausedAnnotation = "bmc.tinkerbell.org/paused"
-
 // BaseboardManagementSpec defines the desired state of BaseboardManagement
 type BaseboardManagementSpec struct {
 
@@ -151,39 +147,6 @@ func WithBaseboardManagementConditionMessage(m string) BaseboardManagementSetCon
 	return func(c *BaseboardManagementCondition) {
 		c.Message = m
 	}
-}
-
-// PauseReconcile adds the pausedAnnotation to the BaseboardManagement object.
-func (bm *BaseboardManagement) PauseReconcile() {
-	if bm.Annotations == nil {
-		bm.initAnnotations()
-	}
-	bm.Annotations[PausedAnnotation] = "true"
-}
-
-// ClearPauseAnnotation deletes the pausedAnnotation from the BaseboardManagement object.
-func (bm *BaseboardManagement) ClearPauseAnnotation() {
-	if bm.Annotations != nil {
-		delete(bm.Annotations, PausedAnnotation)
-	}
-}
-
-// IsReconcilePaused checks if the pausedAnnotation is present on the BaseboardManagement object.
-func (bm *BaseboardManagement) IsReconcilePaused() bool {
-	if bm.Annotations == nil {
-		return false
-	}
-
-	if s, ok := bm.Annotations[PausedAnnotation]; ok {
-		return s == "true"
-	}
-
-	return false
-}
-
-// initAnnotations initalizes the BaseboardManagement metadata annotations.
-func (bm *BaseboardManagement) initAnnotations() {
-	bm.Annotations = map[string]string{}
 }
 
 // BaseboardManagementRef defines the reference information to a BaseboardManagement resource.

--- a/api/v1alpha1/baseboardmanagement_types.go
+++ b/api/v1alpha1/baseboardmanagement_types.go
@@ -65,10 +65,6 @@ type BaseboardManagementSpec struct {
 
 	// Connection represents the BaseboardManagement connectivity information.
 	Connection Connection `json:"connection"`
-
-	// Power is the desired power state of the BaseboardManagement.
-	// +kubebuilder:validation:Enum=on;off
-	Power PowerState `json:"power"`
 }
 
 type Connection struct {

--- a/config/crd/bases/bmc.tinkerbell.org_baseboardmanagements.yaml
+++ b/config/crd/bases/bmc.tinkerbell.org_baseboardmanagements.yaml
@@ -75,15 +75,8 @@ spec:
                 - insecureTLS
                 - port
                 type: object
-              power:
-                description: Power is the desired power state of the BaseboardManagement.
-                enum:
-                - "on"
-                - "off"
-                type: string
             required:
             - connection
-            - power
             type: object
           status:
             description: BaseboardManagementStatus defines the observed state of BaseboardManagement

--- a/controllers/baseboardmanagement_controller.go
+++ b/controllers/baseboardmanagement_controller.go
@@ -85,8 +85,7 @@ type baseboardManagementFieldReconciler func(context.Context, *bmcv1alpha1.Baseb
 
 // Reconcile ensures the state of a BaseboardManagement.
 // Gets the BaseboardManagement object and uses the SecretReference to initialize a BMC Client.
-// Ensures the BMC power is set to the desired state.
-// Updates the status and conditions accordingly.
+// Updates the Power status and conditions accordingly.
 func (r *BaseboardManagementReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.logger.WithValues("BaseboardManagement", req.NamespacedName)
 	logger.Info("Reconciling BaseboardManagement")
@@ -182,22 +181,8 @@ func (r *BaseboardManagementReconciler) reconcilePower(ctx context.Context, bm *
 		return fmt.Errorf("failed to get power state: %v", err)
 	}
 
-	// If BaseboardManagement has desired power state then return
-	if bm.Spec.Power == bmcv1alpha1.PowerState(strings.ToLower(powerStatus)) {
-		// Update status to represent current power state
-		bm.Status.Power = bm.Spec.Power
-		return nil
-	}
-
-	// Setting baseboard management to desired power state
-	_, err = bmcClient.SetPowerState(ctx, string(bm.Spec.Power))
-	if err != nil {
-		r.recorder.Eventf(bm, corev1.EventTypeWarning, EventSetPowerStateFailed, "failed to set power state: %v", err)
-		return fmt.Errorf("failed to set power state: %v", err)
-	}
-
 	// Update status to represent current power state
-	bm.Status.Power = bm.Spec.Power
+	bm.Status.Power = bmcv1alpha1.PowerState(strings.ToLower(powerStatus))
 
 	return nil
 }

--- a/controllers/baseboardmanagement_controller.go
+++ b/controllers/baseboardmanagement_controller.go
@@ -102,12 +102,6 @@ func (r *BaseboardManagementReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, err
 	}
 
-	// If BaseboardManagement is paused, noop.
-	if baseboardManagement.IsReconcilePaused() {
-		logger.Info("BaseboardManagement reconciliation is paused")
-		return ctrl.Result{}, nil
-	}
-
 	// Deletion is a noop.
 	if !baseboardManagement.DeletionTimestamp.IsZero() {
 		return ctrl.Result{}, nil


### PR DESCRIPTION
## Description
Changes convert BaseboardManagement controller to only fetch the current power status of the machine BMC.
Also removed pause annotation as they are unused. 

## Why is this needed
This enforces the actions only from BMCJobs, this prevents overlap in state between BaseboardManagement controller and BMCJobs.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
