### PR TITLE
removed kubeNamespace override

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,14 +79,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	if kubeNamespace == "" {
-		namespace, _, err := ccfg.Namespace()
-		if err != nil {
-			setupLog.Error(err, "unable to get client config namespace")
-			os.Exit(1)
-		}
-		kubeNamespace = namespace
-	}
 	setupLog.Info("Watching objects in namespace for reconciliation", "namespace", kubeNamespace)
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{


### PR DESCRIPTION
Signed-off-by: Gaurav Mehta <gaurav@rancher.com>

## Description

<!--- Please describe what this PR is going to change -->
PR fixes a minor issue with kubeNamespace override based on sa credentials.

By default the controller needs to watch for objects across all namespaces. 

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: # https://github.com/tinkerbell/rufio/issues/15

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
