### PR TITLE
Build images and push to quay.io

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,25 +43,48 @@ jobs:
         with:
           go-version: "1.18"
 
-      - name: make test
+      - name: Unit test
         run: make test
 
-      - name: upload codecov
+      - name: Upload coverage report
         run: bash <(curl -s https://codecov.io/bash)
 
-  build:
+  image:
     runs-on: ubuntu-latest
     needs:
-      - test
       - verify
+      - test
+      - build
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.18"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-      - name: compile binaries
-        run: make build
+      - name: Login to quay.io
+        uses: docker/login-action@v1
+        if: ${{ startsWith(github.ref, 'refs/heads/main') }}
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Docker build meta
+        id: image-meta
+        uses: docker/metadata-action@v4
+        with:
+          images: quay.io/tinkerbell/rufio
+          tags: |
+            type=ref,event=pr
+            type=sha
+
+      - name: Docker build quay.io/tinkerbell/rufio
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          cache-from: type=registry,ref=quay.io/tinkerbell/rufio:latest
+          push: ${{ startsWith(github.ref, 'refs/heads/main') }}
+          tags: ${{ steps.image-meta.outputs.tags }}
+          platforms: linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.18 as builder
+FROM golang:1.18 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -17,10 +17,10 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 FROM alpine:3.15
 
+# Install ipmitool required by the third party BMC lib.
 RUN apk add --upgrade ipmitool=1.8.18-r10
 
-WORKDIR /
 COPY --from=builder /workspace/manager .
-USER 65532:65532
 
+USER 65532:65532
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Build docker images for Rufio on the CI and push to quay.io.

This currently only supports amd64. We can expand to other builds by leveraging Go's cross compilation feature for speed as we've observed, in other projects, the cross docker build to be quite slow.

Closes #26 