### PR TITLE
Add unit tests for job controller

### DIFF
--- a/api/v1alpha1/job.go
+++ b/api/v1alpha1/job.go
@@ -47,6 +47,12 @@ const (
 	Status       PowerAction = "status"
 )
 
+// Pointer provides an easy way to retrieve the power action as a pointer for use in job
+// tasks.
+func (p PowerAction) Pointer() *PowerAction {
+	return &p
+}
+
 // JobSpec defines the desired state of Job
 type JobSpec struct {
 	// MachineRef represents the Machine resource to execute the job.

--- a/api/v1alpha1/machine.go
+++ b/api/v1alpha1/machine.go
@@ -21,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// PowerState represents power state the Machine.
+// PowerState represents power state of a Machine.
 type PowerState string
 
 const (

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -1,0 +1,44 @@
+package controllers_test
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	rufiov1alpha1 "github.com/tinkerbell/rufio/api/v1alpha1"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// This source file is currently a bucket of stuff. If it grows too big, consider breaking it
+// into more granular helper sources.
+
+// createKubeClientBuilder creates a fake kube client builder loaded with Rufio's and Kubernetes'
+// corev1 schemes.
+func createKubeClientBuilder() *fake.ClientBuilder {
+	scheme := runtime.NewScheme()
+	if err := rufiov1alpha1.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme)
+}
+
+// mustCreateLogr creates a logr.Logger implementation backed by a debug style sink. It panics
+// if the logger fails to create.
+func mustCreateLogr(name ...string) logr.Logger {
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		panic(err)
+	}
+
+	if len(name) == 1 {
+		logger = logger.Named(name[0])
+	}
+
+	return zapr.NewLogger(logger)
+}

--- a/controllers/job_controller_test.go
+++ b/controllers/job_controller_test.go
@@ -1,0 +1,165 @@
+package controllers_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	bmcv1alpha1 "github.com/tinkerbell/rufio/api/v1alpha1"
+	"github.com/tinkerbell/rufio/controllers"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestJobReconciler_TasklessJob(t *testing.T) {
+	g := gomega.NewWithT(t)
+	logger := mustCreateLogr()
+
+	machine := createMachine()
+	secret := createSecret()
+	job := createJob("test", machine)
+
+	builder := createKubeClientBuilder()
+	builder.WithObjects(machine, secret, job)
+	kubeClient := builder.Build()
+
+	reconciler := controllers.NewJobReconciler(kubeClient, logger)
+
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: job.Namespace,
+			Name:      job.Name,
+		},
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), request)
+	g.Expect(err).To(gomega.Succeed())
+	g.Expect(result).To(gomega.Equal(reconcile.Result{}))
+
+	var retrieved bmcv1alpha1.Job
+	err = kubeClient.Get(context.Background(), request.NamespacedName, &retrieved)
+	g.Expect(err).To(gomega.Succeed())
+}
+
+func TestJobReconciler_UnknownMachine(t *testing.T) {
+	g := gomega.NewWithT(t)
+	logger := mustCreateLogr()
+
+	secret := createSecret()
+	job := &bmcv1alpha1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test",
+		},
+		Spec: bmcv1alpha1.JobSpec{
+			MachineRef: corev1.ObjectReference{Name: "unknown", Namespace: "default"},
+			Tasks:      []bmcv1alpha1.Action{},
+		},
+	}
+
+	builder := createKubeClientBuilder()
+	builder.WithObjects(secret, job)
+	kubeClient := builder.Build()
+
+	reconciler := controllers.NewJobReconciler(kubeClient, logger)
+
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: job.Namespace,
+			Name:      job.Name,
+		},
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), request)
+	g.Expect(err).To(gomega.HaveOccurred())
+}
+
+func TestJobReconciler_Reconcile(t *testing.T) {
+	machine := createMachine()
+	secret := createSecret()
+
+	for name, action := range map[string]bmcv1alpha1.Action{
+		"PowerAction": {PowerAction: bmcv1alpha1.PowerOn.Pointer()},
+		"OneTimeBootDeviceAction": {
+			OneTimeBootDeviceAction: &bmcv1alpha1.OneTimeBootDeviceAction{
+				Devices: []bmcv1alpha1.BootDevice{bmcv1alpha1.PXE},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			logger := mustCreateLogr(t.Name())
+
+			// We use a fake client with reduced capabilities so always create a new one.
+			builder := createKubeClientBuilder()
+			builder.WithObjects(machine, secret)
+			kubeClient := builder.Build()
+
+			job := createJob(name, machine)
+			job.Spec.Tasks = append(job.Spec.Tasks, action)
+			err := kubeClient.Create(context.Background(), job)
+			g.Expect(err).To(gomega.Succeed())
+
+			request := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: job.Namespace,
+					Name:      job.Name,
+				},
+			}
+
+			// Create the reconciler and trigger initial reconciliation.
+			reconciler := controllers.NewJobReconciler(kubeClient, logger)
+			result, err := reconciler.Reconcile(context.Background(), request)
+			g.Expect(err).To(gomega.Succeed())
+			g.Expect(result).To(gomega.Equal(reconcile.Result{}))
+
+			// Ensure the job successfully reconciled and appropriate tasks exist.
+			var retrieved1 bmcv1alpha1.Job
+			err = kubeClient.Get(context.Background(), request.NamespacedName, &retrieved1)
+			g.Expect(err).To(gomega.Succeed())
+			g.Expect(retrieved1.Status.StartTime.Unix()).To(gomega.BeNumerically("~", time.Now().Unix(), 10))
+			g.Expect(retrieved1.Status.CompletionTime.IsZero()).To(gomega.BeTrue())
+			g.Expect(retrieved1.Status.Conditions).To(gomega.HaveLen(1))
+			g.Expect(retrieved1.Status.Conditions[0].Type).To(gomega.Equal(bmcv1alpha1.JobRunning))
+			g.Expect(retrieved1.Status.Conditions[0].Status).To(gomega.Equal(bmcv1alpha1.ConditionTrue))
+
+			var task bmcv1alpha1.Task
+			taskKey := types.NamespacedName{
+				Namespace: job.Namespace,
+				Name:      bmcv1alpha1.FormatTaskName(*job, 0),
+			}
+			err = kubeClient.Get(context.Background(), taskKey, &task)
+			g.Expect(err).To(gomega.Succeed())
+			g.Expect(task.Spec.Task).To(gomega.BeEquivalentTo(job.Spec.Tasks[0]))
+			g.Expect(task.OwnerReferences).To(gomega.HaveLen(1))
+			g.Expect(task.OwnerReferences[0].Name).To(gomega.Equal(job.Name))
+			g.Expect(task.OwnerReferences[0].Kind).To(gomega.Equal("Job"))
+
+			// Ensure re-reconciling a job does nothing given the task is still outstanding.
+			result, err = reconciler.Reconcile(context.Background(), request)
+			g.Expect(err).To(gomega.Succeed())
+			g.Expect(result).To(gomega.Equal(reconcile.Result{}))
+
+			var retrieved2 bmcv1alpha1.Job
+			err = kubeClient.Get(context.Background(), request.NamespacedName, &retrieved2)
+			g.Expect(err).To(gomega.Succeed())
+			g.Expect(retrieved2).To(gomega.BeEquivalentTo(retrieved1))
+		})
+	}
+}
+
+func createJob(name string, machine *bmcv1alpha1.Machine) *bmcv1alpha1.Job {
+	return &bmcv1alpha1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      name,
+		},
+		Spec: bmcv1alpha1.JobSpec{
+			MachineRef: corev1.ObjectReference{Name: machine.Name, Namespace: machine.Namespace},
+			Tasks:      []bmcv1alpha1.Action{},
+		},
+	}
+}

--- a/controllers/machine_controller_test.go
+++ b/controllers/machine_controller_test.go
@@ -28,8 +28,8 @@ func TestReconcileGetPowerStateSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockBMCClient := mocks.NewMockBMCClient(ctrl)
 
-	bm := getMachine()
-	authSecret := getSecret()
+	bm := createMachine()
+	authSecret := createSecret()
 
 	objs := []runtime.Object{bm, authSecret}
 	scheme := runtime.NewScheme()
@@ -68,7 +68,7 @@ func TestReconcileSecretReferenceError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockBMCClient := mocks.NewMockBMCClient(ctrl)
 
-	bm := getMachine()
+	bm := createMachine()
 
 	scheme := runtime.NewScheme()
 	_ = bmcv1alpha1.AddToScheme(scheme)
@@ -137,8 +137,8 @@ func TestReconcileConnectionError(t *testing.T) {
 
 	ctx := context.Background()
 
-	bm := getMachine()
-	authSecret := getSecret()
+	bm := createMachine()
+	authSecret := createSecret()
 
 	objs := []runtime.Object{bm, authSecret}
 	scheme := runtime.NewScheme()
@@ -173,8 +173,8 @@ func TestReconcileGetPowerStateError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockBMCClient := mocks.NewMockBMCClient(ctrl)
 
-	bm := getMachine()
-	authSecret := getSecret()
+	bm := createMachine()
+	authSecret := createSecret()
 
 	objs := []runtime.Object{bm, authSecret}
 	scheme := runtime.NewScheme()
@@ -221,7 +221,7 @@ func newMockBMCClientFactoryFuncError() controllers.BMCClientFactoryFunc {
 	}
 }
 
-func getMachine() *bmcv1alpha1.Machine {
+func createMachine() *bmcv1alpha1.Machine {
 	return &bmcv1alpha1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-bm",
@@ -241,7 +241,7 @@ func getMachine() *bmcv1alpha1.Machine {
 	}
 }
 
-func getSecret() *corev1.Secret {
+func createSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test-namespace",


### PR DESCRIPTION
Add unit tests that focus on ensuring reconciliation modifies the underlying object with what we expect.

In addition to Task controller unit tests, there will be integration tests that validate the Job controller and Task controller interact correctly.