### PR TITLE
Patch zlib vuln CVE-2022-37434

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM --platform=$BUILDPLATFORM golang:1.18 AS builder
 
 WORKDIR /workspace
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -15,7 +16,7 @@ COPY ./ ./
 # Build
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o manager main.go
 
-FROM alpine:3.15
+FROM alpine:3.16
 
 # Install ipmitool required by the third party BMC lib.
 RUN apk add --upgrade ipmitool=1.8.18-r10


### PR DESCRIPTION
Patch CVE-2022-37434 by upgrading to Alpine 3.16.