### PR TITLE
Making cluster wide read default for Secrets

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -9,8 +9,6 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
-- secrets_viewer_role.yaml
-- secrets_viewer_role_binding.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - bmc.tinkerbell.org
   resources:
   - jobs

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -64,6 +64,7 @@ type machineFieldReconciler func(context.Context, *bmcv1alpha1.Machine, BMCClien
 //+kubebuilder:rbac:groups=bmc.tinkerbell.org,resources=machines,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=bmc.tinkerbell.org,resources=machines/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=bmc.tinkerbell.org,resources=machines/finalizers,verbs=update
+//+kubebuilder:rbac:groups="",resources=secrets;,verbs=get;list;watch
 
 // Reconcile ensures the state of a Machine.
 // Gets the Machine object and uses the SecretReference to initialize a BMC Client.


### PR DESCRIPTION
## Description
Making cluster wide read default for `Secrets` and removed secrets namespaced read role. Currently the default manifest generated does not work, due to secrets read permissions.

```
E0830 19:14:39.783530       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.23.0/tools/cache/reflector.go:167: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:rufio-system:rufio-controller-manager" cannot list resource "secrets" in API group "" at the cluster scope

```
Now by default Rufio runs Cluster scoped and users can modify the permissions to have Rufio run on a namespaced scope.

## Why is this needed
This is a potential solution to #62 

## How Has This Been Tested?
```
make release-manifests
kubectl apply -f manifest.yaml
```
