### PR TITLE
Task power state parsing fix

### DIFF
--- a/controllers/job_controller.go
+++ b/controllers/job_controller.go
@@ -129,7 +129,7 @@ func (r *JobReconciler) reconcile(ctx context.Context, job *bmcv1alpha1.Job, job
 		}
 
 		if task.HasCondition(bmcv1alpha1.TaskFailed, bmcv1alpha1.ConditionTrue) {
-			err := fmt.Errorf("Task %s/%s failed", task.Namespace, task.Name)
+			err := fmt.Errorf("task %s/%s failed", task.Namespace, task.Name)
 			job.SetCondition(bmcv1alpha1.JobFailed, bmcv1alpha1.ConditionTrue, bmcv1alpha1.WithJobConditionMessage(err.Error()))
 			patchErr := r.patchStatus(ctx, job, jobPatch)
 			if patchErr != nil {
@@ -176,7 +176,7 @@ func (r *JobReconciler) getMachine(ctx context.Context, reference corev1.ObjectR
 	err := r.client.Get(ctx, key, machine)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return fmt.Errorf("Machine %s not found: %v", key, err)
+			return fmt.Errorf("machine %s not found: %v", key, err)
 		}
 		return fmt.Errorf("failed to get Machine %s: %v", key, err)
 	}

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -31,7 +31,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/tinkerbell/rufio/api/v1alpha1"
 	bmcv1alpha1 "github.com/tinkerbell/rufio/api/v1alpha1"
 )
 
@@ -180,15 +179,15 @@ func (r *MachineReconciler) patchStatus(ctx context.Context, bm *bmcv1alpha1.Mac
 
 // convertRawBMCPowerState takes a raw BMC power state response and attempts to convert it to
 // a PowerState.
-func convertRawBMCPowerState(response string) (v1alpha1.PowerState, error) {
+func convertRawBMCPowerState(response string) (bmcv1alpha1.PowerState, error) {
 	// Normalize the response string for comparison.
 	response = strings.ToLower(response)
 
 	switch {
 	case strings.Contains(response, "on"):
-		return v1alpha1.On, nil
+		return bmcv1alpha1.On, nil
 	case strings.Contains(response, "off"):
-		return v1alpha1.Off, nil
+		return bmcv1alpha1.Off, nil
 	}
 
 	return "", fmt.Errorf("unknown bmc power state: %v", response)

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,12 @@ go 1.18
 require (
 	github.com/bmc-toolbox/bmclib v0.5.3
 	github.com/go-logr/logr v1.2.3
+	github.com/go-logr/zapr v1.2.0
 	github.com/golang/mock v1.6.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/spf13/pflag v1.0.5
+	go.uber.org/zap v1.19.1
 	golang.org/x/tools v0.1.6-0.20210820212750-d4cc65f0b2ff
 	k8s.io/api v0.23.0
 	k8s.io/apimachinery v0.23.0
@@ -30,7 +32,6 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/go-logr/zapr v1.2.0 // indirect
 	github.com/go-playground/locales v0.13.0 // indirect
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -58,7 +59,6 @@ require (
 	github.com/stmcginnis/gofish v0.12.1-0.20220311113027-6072260f4c8d // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f // indirect


### PR DESCRIPTION
## Description
Adding a similar parsing logic to Machine controller when a Task status gets checked.

Fixes: #64 

## How Has This Been Tested?
```
kubectl apply -f manifest.yaml
kubectl apply -f machine.yaml
kubectl apply -f machine-job.yaml
```

Tested against a `Supermicro` where `ipmitool` returns `Chassis Power is on`
