### PR TITLE
Change reference object in Job's to a specialized MachineRef

### DIFF
--- a/api/v1alpha1/job.go
+++ b/api/v1alpha1/job.go
@@ -19,7 +19,6 @@ package v1alpha1
 import (
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -35,11 +34,20 @@ const (
 	JobRunning JobConditionType = "Running"
 )
 
+// MachineRef is used to reference a Machine object.
+type MachineRef struct {
+	// Name of the Machine.
+	Name string `json:"name"`
+
+	// Namespace the Machine resides in.
+	Namespace string `json:"namespace"`
+}
+
 // JobSpec defines the desired state of Job
 type JobSpec struct {
 	// MachineRef represents the Machine resource to execute the job.
 	// All the tasks in the job are executed for the same Machine.
-	MachineRef corev1.ObjectReference `json:"machineRef"`
+	MachineRef MachineRef `json:"machineRef"`
 
 	// Tasks represents a list of baseboard management actions to be executed.
 	// The tasks are executed sequentially. Controller waits for one task to complete before executing the next.

--- a/controllers/job_controller.go
+++ b/controllers/job_controller.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -171,7 +170,7 @@ func (r *JobReconciler) reconcile(ctx context.Context, job *bmcv1alpha1.Job, job
 }
 
 // getMachine Gets the Machine from MachineRef
-func (r *JobReconciler) getMachine(ctx context.Context, reference corev1.ObjectReference, machine *bmcv1alpha1.Machine) error {
+func (r *JobReconciler) getMachine(ctx context.Context, reference bmcv1alpha1.MachineRef, machine *bmcv1alpha1.Machine) error {
 	key := types.NamespacedName{Namespace: reference.Namespace, Name: reference.Name}
 	err := r.client.Get(ctx, key, machine)
 	if err != nil {

--- a/controllers/job_controller_test.go
+++ b/controllers/job_controller_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/onsi/gomega"
 	bmcv1alpha1 "github.com/tinkerbell/rufio/api/v1alpha1"
 	"github.com/tinkerbell/rufio/controllers"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -55,7 +54,7 @@ func TestJobReconciler_UnknownMachine(t *testing.T) {
 			Name:      "test",
 		},
 		Spec: bmcv1alpha1.JobSpec{
-			MachineRef: corev1.ObjectReference{Name: "unknown", Namespace: "default"},
+			MachineRef: bmcv1alpha1.MachineRef{Name: "unknown", Namespace: "default"},
 			Tasks:      []bmcv1alpha1.Action{},
 		},
 	}
@@ -151,7 +150,7 @@ func createJob(name string, machine *bmcv1alpha1.Machine) *bmcv1alpha1.Job {
 			Name:      name,
 		},
 		Spec: bmcv1alpha1.JobSpec{
-			MachineRef: corev1.ObjectReference{Name: machine.Name, Namespace: machine.Namespace},
+			MachineRef: bmcv1alpha1.MachineRef{Name: machine.Name, Namespace: machine.Namespace},
 			Tasks:      []bmcv1alpha1.Action{},
 		},
 	}


### PR DESCRIPTION
The ObjectRefernce used by Job's is too broad as it contains fields relating to FieldPaths, Groups, API Versions and more that aren't required for Machine object reference.

This was proposed by \<enter name\> some time ago and we never implemented it.