### PR TITLE
Push images on release branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Login to quay.io
         uses: docker/login-action@v1
-        if: ${{ startsWith(github.ref, 'refs/heads/main') }}
+        if: ${{ startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/v') }}
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -87,4 +87,4 @@ jobs:
           cache-from: type=registry,ref=quay.io/tinkerbell/rufio:latest
           tags: ${{ steps.image-meta.outputs.tags }}
           platforms: linux/amd64,linux/arm64
-          push: ${{ startsWith(github.ref, 'refs/heads/main') }}
+          push: ${{ startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/v') }}


### PR DESCRIPTION
Patch the CI workflow to build images on release branches. This allows us to follow the normal releasing process that re-tags images pre-built on `main` or, with this change, `v*` branches.