### PR TITLE
Get Dockerfile env vars properly working:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,12 @@ RUN go mod download
 # Copy the go source
 COPY ./ ./
 
+# Define args for the target platform so we can identify the binary in the Docker context.
+# These args are populated by Docker. The values should match Go's GOOS and GOARCH values for
+# the respective os/platform.
+ARG TARGETARCH
+ARG TARGETOS
+
 # Build
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o manager main.go
 


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
The `TARGETARCH` and `TARGETOS `env vars weren't making it to the `go build` command so the `GOOS` and `GOARCH` were would be empty and the build would only use amd64.

## Why is this needed

<!--- Link to issue you have raised -->
Manually tested by running this locally: 
`docker buildx build --cache-from type=registry,ref=quay.io/tinkerbell/rufio:latest --file ./Dockerfile --load -t rufio:test --platform linux/arm64 ./`
and then extracting the `manager` binary and validate the binary type to be`ARM aarch64`.


Also, locally in the build logs you see `[builder 7/7] RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -o manager main.go` versus in the GitHub actions log you see `[linux/amd64 builder 7/7] RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o manager main.go`
https://github.com/tinkerbell/rufio/actions/runs/3831046658/jobs/6519718105#step:6:269
Fixes: #74 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
