### PR TITLE
Adding Using() to select bmc-lib drivers for client

### DIFF
--- a/controllers/bmc_client.go
+++ b/controllers/bmc_client.go
@@ -37,6 +37,9 @@ func NewBMCClientFactoryFunc(ctx context.Context) BMCClientFactoryFunc {
 	return func(ctx context.Context, hostIP, port, username, password string) (BMCClient, error) {
 		client := bmclib.NewClient(hostIP, port, username, password)
 
+		using := client.Registry.Using
+		client.Registry.Drivers = append(using("redfish"), using("ipmi")...)
+
 		// TODO (pokearu): Make an option
 		client.Registry.Drivers = client.Registry.PreferDriver("gofish")
 		if err := client.Open(ctx); err != nil {


### PR DESCRIPTION
## Description
bmc-lib tries to establish a connection to check compatible protocols (redfish, ipmi etc) for all supported implementations. These changes modify Rufio to only use `Redfish` and `IPMI` protocols for all hardware.

## Why is this needed
Rufio opens a new connection via bmc-lib for every reconcile loop. In the latest version of bmc-lib support for IntelAMT protocol was added. It was noticed that on older hardware when users try to run Rufio, IntelAMT takes too long to establish a connection and hence blocks the reconcile thread. This was causing timeouts of Rufio Tasks when it exceeded 3 mins to hit the connection timeout. 

Fixes:
Timeout issues on older hardware due to Rufio reconcile threads getting blocked when bmc-lib provider open connection calls hang and timeout. 

## How Has This Been Tested?
`make docker-build` and tested the controller.

## How are existing users impacted? What migration steps/scripts do we need?
Unblocks existing users who are running Rufio for older hardware.
