### PR TITLE
Update go.mod to 1.20:

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tinkerbell/rufio
 
-go 1.18
+go 1.20
 
 require (
 	github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20230511130410-5f3cb3510c90


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
The `sigs.k8s.io/controller-runtime v0.14.6` dependency requires `k8s.io/kube-openapi v0.0.0-20230308215209-15aac26d736a` which does not build with Go 1.18.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #112 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
