### PR TITLE
Update ipmitool: 1.8.19-r0 -> 1.8.19-r1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o manager main.
 FROM alpine:3.18
 
 # Install ipmitool required by the third party BMC lib.
-RUN apk add --upgrade ipmitool=1.8.19-r0
+RUN apk add --upgrade ipmitool=1.8.19-r1
 
 COPY --from=builder /workspace/manager .
 


### PR DESCRIPTION
Alpine was recently updated from 3.17 to 3.18. Oddly, the build passed, however this package seems to have been updated with `r0` being removed.

This change should allow us to merge the other dependency updates like https://github.com/tinkerbell/rufio/pull/120