### PR TITLE
Create a manager cache only when a ns is specified:

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,18 +116,23 @@ func main() {
 
 	setupLog.Info("Watching objects in namespace for reconciliation", "namespace", kubeNamespace)
 
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+	opts := ctrl.Options{
 		Scheme: scheme,
-		Cache: cache.Options{
-			DefaultNamespaces: map[string]cache.Config{kubeNamespace: {}},
-		},
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
 		},
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "e74dec1a.tinkerbell.org",
-	})
+	}
+	// If a namespace is specified, only watch that namespace. Otherwise, watch all namespaces.
+	if kubeNamespace != "" {
+		opts.Cache = cache.Options{
+			DefaultNamespaces: map[string]cache.Config{kubeNamespace: {}},
+		}
+	}
+
+	mgr, err := ctrl.NewManager(cfg, opts)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
A cache with a "" namespace causes reconcile errors:
_"unable to get: namespace/machine because of unknown namespace for the cache"_

With this change if the namespace is `""` we use the default behavior of the manager which is to watch and list all namespaces.

I believe this was the behavior before we upgrade the controller runtime.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
