### PR TITLE
feat(intelAMT): add support for HTTPS connections

### DIFF
--- a/api/v1alpha1/provider_opts.go
+++ b/api/v1alpha1/provider_opts.go
@@ -27,7 +27,7 @@ type IntelAMTOptions struct {
 	// Port that intelAMT will use for calls.
 	Port int `json:"port"`
 
-	// UseHttp determines whether to use http or https for intelAMT calls.
+	// HostScheme determines whether to use http or https for intelAMT calls.
 	// +optional
 	// +kubebuilder:validation:Enum=http;https
 	// +kubebuilder:default:=http

--- a/api/v1alpha1/provider_opts.go
+++ b/api/v1alpha1/provider_opts.go
@@ -26,6 +26,12 @@ type IPMITOOLOptions struct {
 type IntelAMTOptions struct {
 	// Port that intelAMT will use for calls.
 	Port int `json:"port"`
+
+	// UseHttp determines whether to use http or https for intelAMT calls.
+	// +optional
+	// +kubebuilder:validation:Enum=http;https
+	// +kubebuilder:default:=http
+	HostScheme string `json:"hostScheme"`
 }
 
 // HMACAlgorithm is a type for HMAC algorithms.

--- a/config/crd/bases/bmc.tinkerbell.org_machines.yaml
+++ b/config/crd/bases/bmc.tinkerbell.org_machines.yaml
@@ -74,6 +74,14 @@ spec:
                         description: IntelAMT contains the options to customize the
                           IntelAMT provider.
                         properties:
+                          hostScheme:
+                            default: http
+                            description: UseHttp determines whether to use http or
+                              https for intelAMT calls.
+                            enum:
+                            - http
+                            - https
+                            type: string
                           port:
                             description: Port that intelAMT will use for calls.
                             type: integer

--- a/config/crd/bases/bmc.tinkerbell.org_machines.yaml
+++ b/config/crd/bases/bmc.tinkerbell.org_machines.yaml
@@ -77,7 +77,7 @@ spec:
                           hostScheme:
                             default: http
                             description: HostScheme determines whether to use http or
-                              https for intelAMT calls.
+                              https for IntelAMT calls.
                             enum:
                             - http
                             - https

--- a/config/crd/bases/bmc.tinkerbell.org_machines.yaml
+++ b/config/crd/bases/bmc.tinkerbell.org_machines.yaml
@@ -76,7 +76,7 @@ spec:
                         properties:
                           hostScheme:
                             default: http
-                            description: UseHttp determines whether to use http or
+                            description: HostScheme determines whether to use http or
                               https for intelAMT calls.
                             enum:
                             - http

--- a/config/crd/bases/bmc.tinkerbell.org_tasks.yaml
+++ b/config/crd/bases/bmc.tinkerbell.org_tasks.yaml
@@ -77,7 +77,7 @@ spec:
                         properties:
                           hostScheme:
                             default: http
-                            description: UseHttp determines whether to use http or
+                            description: HostScheme determines whether to use http or
                               https for intelAMT calls.
                             enum:
                             - http

--- a/config/crd/bases/bmc.tinkerbell.org_tasks.yaml
+++ b/config/crd/bases/bmc.tinkerbell.org_tasks.yaml
@@ -78,7 +78,7 @@ spec:
                           hostScheme:
                             default: http
                             description: HostScheme determines whether to use http or
-                              https for intelAMT calls.
+                              https for IntelAMT calls.
                             enum:
                             - http
                             - https

--- a/config/crd/bases/bmc.tinkerbell.org_tasks.yaml
+++ b/config/crd/bases/bmc.tinkerbell.org_tasks.yaml
@@ -75,6 +75,14 @@ spec:
                         description: IntelAMT contains the options to customize the
                           IntelAMT provider.
                         properties:
+                          hostScheme:
+                            default: http
+                            description: UseHttp determines whether to use http or
+                              https for intelAMT calls.
+                            enum:
+                            - http
+                            - https
+                            type: string
                           port:
                             description: Port that intelAMT will use for calls.
                             type: integer

--- a/controller/client.go
+++ b/controller/client.go
@@ -77,8 +77,9 @@ func (b BMCOptions) Translate(host string) []bmclib.Option {
 
 	// intelAmt options
 	if b.IntelAMT != nil {
-		amt := bmclib.WithIntelAMTPort(uint32(b.IntelAMT.Port))
-		o = append(o, amt)
+		amtPort := bmclib.WithIntelAMTPort(uint32(b.IntelAMT.Port))
+		amtScheme := bmclib.WithIntelAMTHostScheme(b.IntelAMT.HostScheme)
+		o = append(o, amtPort, amtScheme)
 	}
 
 	// rpc options


### PR DESCRIPTION
## Description

This pull request add support for HTTPS connections with Intel AMT BMCs. Currently `bmclib` uses `http` as a default connection scheme which is not supported on modern AMT platforms (like the Minisforum MS-01 that I used to test this change), and there is no way to set the connection scheme to https with the current `Machine` API. 

## Why is this needed

This is needed to add support for AMT hosts that only support HTTPS connection scheme.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

These changes were tested against a Minisforum MS-01 PC that only supports HTTPS AMT. A `Machine` was created that couldn't fetch the powerstate since the authentication would fail because the client would default to `http`. With these changes, `rufio` can successfully interact with the AMT BMC on the computer using https scheme.


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->

No migration is needed, the new `hostScheme` field defaults to `http` which keeps the default behavior.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [x] provided instructions on how to upgrade
