### PR TITLE
Update bmclib version:

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.2
 
 require (
 	dario.cat/mergo v1.0.1
-	github.com/bmc-toolbox/bmclib/v2 v2.3.5-0.20241124181818-eb78b9e0a6f9
+	github.com/bmc-toolbox/bmclib/v2 v2.3.5-0.20241214123342-adcf7f1ea7fc
 	github.com/ccoveille/go-safecast v1.2.0
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zerologr v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/VictorLowther/soap v0.0.0-20150314151524-8e36fca84b22 h1:a0MBqYm44o0N
 github.com/VictorLowther/soap v0.0.0-20150314151524-8e36fca84b22/go.mod h1:/B7V22rcz4860iDqstGvia/2+IYWXf3/JdQCVd/1D2A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bmc-toolbox/bmclib/v2 v2.3.5-0.20241124181818-eb78b9e0a6f9 h1:75mzipiXyzstsWFsnXYsTKgZhQxG5VwCETo0DTVpftM=
-github.com/bmc-toolbox/bmclib/v2 v2.3.5-0.20241124181818-eb78b9e0a6f9/go.mod h1:t8If/0fHQTRIK/yKDk2H3SgthDNNj+7z2aeftDFRFrU=
+github.com/bmc-toolbox/bmclib/v2 v2.3.5-0.20241214123342-adcf7f1ea7fc h1:oL9mbdSQsYP1pj3diJpsAspfkoOjq9/FoZVlI+avunM=
+github.com/bmc-toolbox/bmclib/v2 v2.3.5-0.20241214123342-adcf7f1ea7fc/go.mod h1:ZS6dzcxbazlBW2Z5ADIgGbEZjkaG96//v2iwvA2V514=
 github.com/bmc-toolbox/common v0.0.0-20240806132831-ba8adc6a35e3 h1:/BjZSX/sphptIdxpYo4wxAQkgMLyMMgfdl48J9DKNeE=
 github.com/bmc-toolbox/common v0.0.0-20240806132831-ba8adc6a35e3/go.mod h1:Cdnkm+edb6C0pVkyCrwh3JTXAe0iUF9diDG/DztPI9I=
 github.com/bombsimon/logrusr/v2 v2.0.1 h1:1VgxVNQMCvjirZIYaT9JYn6sAVGVEcNtRE0y4mvaOAM=


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Fixes a nil pointer panic when running in environments (container images like scratch) that don't have the "sum" binary. In bmclib the "sum" binary is the supermicro update manager, but in most OS distros "sum" is a command for "checksum and count the blocks in a file". This means that we didn't see the panic because we are running in Alpine that has a "sum" binary.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
