### PR TITLE
Add CAPI labels to Machine CRD:

### DIFF
--- a/api/v1alpha1/machine.go
+++ b/api/v1alpha1/machine.go
@@ -182,6 +182,8 @@ func WithMachineConditionMessage(m string) MachineSetConditionOption {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:path=machines,scope=Namespaced,categories=tinkerbell,singular=machine
+// +kubebuilder:metadata:labels=clusterctl.cluster.x-k8s.io=
+// +kubebuilder:metadata:labels=clusterctl.cluster.x-k8s.io/move=
 
 // Machine is the Schema for the machines API.
 type Machine struct {

--- a/config/crd/bases/bmc.tinkerbell.org_machines.yaml
+++ b/config/crd/bases/bmc.tinkerbell.org_machines.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.4
+  labels:
+    clusterctl.cluster.x-k8s.io: ""
+    clusterctl.cluster.x-k8s.io/move: ""
   name: machines.bmc.tinkerbell.org
 spec:
   group: bmc.tinkerbell.org


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
These labels allow CAPI to move the Machine CR's during a clusterctl move command. This won't affect non CAPI use.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
