### PR TITLE
Prevent nil pointer exception while reconciling w/ RPC provider

### DIFF
--- a/controller/machine.go
+++ b/controller/machine.go
@@ -98,7 +98,7 @@ func (r *MachineReconciler) doReconcile(ctx context.Context, bm *v1alpha1.Machin
 	}
 	if bm.Spec.Connection.ProviderOptions != nil && bm.Spec.Connection.ProviderOptions.RPC != nil {
 		opts.ProviderOptions = bm.Spec.Connection.ProviderOptions
-		if len(bm.Spec.Connection.ProviderOptions.RPC.HMAC.Secrets) > 0 {
+		if bm.Spec.Connection.ProviderOptions.RPC.HMAC != nil && len(bm.Spec.Connection.ProviderOptions.RPC.HMAC.Secrets) > 0 {
 			se, err := retrieveHMACSecrets(ctx, r.client, bm.Spec.Connection.ProviderOptions.RPC.HMAC.Secrets)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("unable to get hmac secrets: %w", err)

--- a/controller/task.go
+++ b/controller/task.go
@@ -93,7 +93,7 @@ func (r *TaskReconciler) doReconcile(ctx context.Context, task *v1alpha1.Task, t
 	}
 	if task.Spec.Connection.ProviderOptions != nil && task.Spec.Connection.ProviderOptions.RPC != nil {
 		opts.ProviderOptions = task.Spec.Connection.ProviderOptions
-		if len(task.Spec.Connection.ProviderOptions.RPC.HMAC.Secrets) > 0 {
+		if task.Spec.Connection.ProviderOptions.RPC.HMAC != nil && len(task.Spec.Connection.ProviderOptions.RPC.HMAC.Secrets) > 0 {
 			se, err := retrieveHMACSecrets(ctx, r.client, task.Spec.Connection.ProviderOptions.RPC.HMAC.Secrets)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("unable to get hmac secrets: %w", err)

--- a/controller/task_test.go
+++ b/controller/task_test.go
@@ -81,6 +81,12 @@ func TestTaskReconcile(t *testing.T) {
 			task:     createTaskWithRPC("PowerOn", getAction("PowerOn"), createHMACSecret()),
 		},
 
+		"success power on with RPC provider w/o secrets": {
+			taskName: "PowerOn",
+			action:   getAction("PowerOn"),
+			provider: &testProvider{Powerstate: "on", PowerSetOK: true, Proto: "rpc"},
+		},
+
 		"failure on bmc open": {
 			taskName: "PowerOn", action: getAction("PowerOn"),
 			provider:  &testProvider{ErrOpen: errors.New("failed to open")},
@@ -259,7 +265,7 @@ func createTask(name string, action v1alpha1.Action, secret *corev1.Secret) *v1a
 }
 
 func createTaskWithRPC(name string, action v1alpha1.Action, secret *corev1.Secret) *v1alpha1.Task {
-	return &v1alpha1.Task{
+	machine := &v1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "default",
@@ -276,19 +282,24 @@ func createTaskWithRPC(name string, action v1alpha1.Action, secret *corev1.Secre
 				ProviderOptions: &v1alpha1.ProviderOptions{
 					RPC: &v1alpha1.RPCOptions{
 						ConsumerURL: "http://127.0.0.1:7777",
-						HMAC: &v1alpha1.HMACOpts{
-							Secrets: v1alpha1.HMACSecrets{
-								"sha256": []corev1.SecretReference{
-									{
-										Name:      secret.Name,
-										Namespace: secret.Namespace,
-									},
-								},
-							},
-						},
 					},
 				},
 			},
 		},
 	}
+
+	if secret != nil {
+		machine.Spec.Connection.ProviderOptions.RPC.HMAC = &v1alpha1.HMACOpts{
+			Secrets: v1alpha1.HMACSecrets{
+				"sha256": []corev1.SecretReference{
+					{
+						Name:      secret.Name,
+						Namespace: secret.Namespace,
+					},
+				},
+			},
+		}
+	}
+
+	return machine
 }

--- a/controller/task_test.go
+++ b/controller/task_test.go
@@ -275,10 +275,6 @@ func createTaskWithRPC(name string, action v1alpha1.Action, secret *corev1.Secre
 			Connection: v1alpha1.Connection{
 				Host: "host",
 				Port: 22,
-				AuthSecretRef: corev1.SecretReference{
-					Name:      secret.Name,
-					Namespace: secret.Namespace,
-				},
 				ProviderOptions: &v1alpha1.ProviderOptions{
 					RPC: &v1alpha1.RPCOptions{
 						ConsumerURL: "http://127.0.0.1:7777",
@@ -289,6 +285,11 @@ func createTaskWithRPC(name string, action v1alpha1.Action, secret *corev1.Secre
 	}
 
 	if secret != nil {
+		machine.Spec.Connection.AuthSecretRef = corev1.SecretReference{
+			Name:      secret.Name,
+			Namespace: secret.Namespace,
+		}
+
 		machine.Spec.Connection.ProviderOptions.RPC.HMAC = &v1alpha1.HMACOpts{
 			Secrets: v1alpha1.HMACSecrets{
 				"sha256": []corev1.SecretReference{


### PR DESCRIPTION
## Description
Prevents nil pointer exception when checking length of `hmac.secrets` for the RPC provider during machine reconciliation. The `hmac` field in the RPC provider options is an optional field, if it is not defined, it will result in nil pointer exception.

## Why is this needed
In `provider_opts.go`, `RPCOptions.HMAC` field is marked as optional.

https://github.com/tinkerbell/rufio/blob/7969e5f160c3138b92cb035e1a9951eb82b39a7a/api/v1alpha1/provider_opts.go#L67-L69

Prior to this change, defining a `Machine`, `Job`, or `Task` using the RPC provider without setting the `hmac` field would result in a nil pointer exception. A user could bypass this by defining an empty flow map, i.e. `hmac: {}`. However, since this field is marked as optional, this isn't clear and this change makes the code consistent with the markup in the API definition.

## How Has This Been Tested?
This PR includes unit tests to test this particular situation where not HMAC secrets are provided.

## How are existing users impacted? What migration steps/scripts do we need?
This PR fixes a bug. Existing users using secrets won't be impacted, and users without secrets will be able to remove a line of yaml from their Rufio-related CRs. No migrations steps are needed.

## Checklist:

I have:
- [ ] ~~updated the documentation and/or roadmap (if required)~~
- [x] added unit or e2e tests
- [ ] ~~provided instructions on how to upgrade~~
