### PR TITLE
Use PreferDriver instead of PreferProtocol:

### DIFF
--- a/controller/client.go
+++ b/controller/client.go
@@ -36,7 +36,7 @@ func NewClientFunc(timeout time.Duration) ClientFunc {
 		defer cancel()
 
 		if opts != nil && opts.ProviderOptions != nil && len(opts.PreferredOrder) > 0 {
-			client.Registry.Drivers = client.Registry.PreferProtocol(toStringSlice(opts.PreferredOrder)...)
+			client.Registry.Drivers = client.Registry.PreferDriver(toStringSlice(opts.PreferredOrder)...)
 		}
 		if err := client.Open(ctx); err != nil {
 			md := client.GetMetadata()

--- a/controller/helpers_test.go
+++ b/controller/helpers_test.go
@@ -58,7 +58,7 @@ func (t *testProvider) Protocol() string {
 	if t.Proto != "" {
 		return t.Proto
 	}
-	return "redfish"
+	return "gofish"
 }
 
 func (t *testProvider) Features() registrar.Features {


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
The API spec defines PreferredOrder to be the driver name not the protocol name. This causes the "gofish" provider to not change the order as that is the driver name not the protocol. The protocol is "redfish". Changing the implementation to use PreferDriver is chosen so as not to have to change the API spec validation.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
