### PR TITLE
Add configurable concurrent reconciliation to controllers

### DIFF
--- a/controller/job.go
+++ b/controller/job.go
@@ -26,6 +26,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 
 	"github.com/tinkerbell/rufio/api/v1alpha1"
@@ -221,7 +222,7 @@ func (r *JobReconciler) patchStatus(ctx context.Context, job *v1alpha1.Job, patc
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *JobReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+func (r *JobReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opts ctrlcontroller.Options) error {
 	if err := mgr.GetFieldIndexer().IndexField(
 		ctx,
 		&v1alpha1.Task{},
@@ -233,6 +234,7 @@ func (r *JobReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) 
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Job{}).
+		WithOptions(opts).
 		Watches(
 			&v1alpha1.Task{},
 			handler.EnqueueRequestForOwner(

--- a/controller/machine.go
+++ b/controller/machine.go
@@ -29,6 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -210,8 +212,9 @@ func retrieveHMACSecrets(ctx context.Context, c client.Client, hmacSecrets v1alp
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *MachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *MachineReconciler) SetupWithManager(mgr ctrl.Manager, opts ctrlcontroller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Machine{}).
+		WithOptions(opts).
 		Complete(r)
 }

--- a/controller/task.go
+++ b/controller/task.go
@@ -25,6 +25,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"github.com/tinkerbell/rufio/api/v1alpha1"
 )
@@ -274,8 +275,9 @@ func (r *TaskReconciler) patchStatus(ctx context.Context, task *v1alpha1.Task, p
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *TaskReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *TaskReconciler) SetupWithManager(mgr ctrl.Manager, opts ctrlcontroller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Task{}).
+		WithOptions(opts).
 		Complete(r)
 }


### PR DESCRIPTION
## Description
The controller-runtime defaults MaxConcurrentReconciles to 1, which creates a bottleneck when multiple BMC operations need to be processed simultaneously. This is particularly noticeable during cluster provisioning when many nodes are being set up in parallel.

This change adds a CLI flag (--max-concurrent-reconciles) and corresponding environment variable (RUFIO_MAX_CONCURRENT_RECONCILES) to configure the number of concurrent reconciliations across all controllers.

<!--- Please describe what this PR is going to change -->

## Why is this needed
Performance testing with 30 nodes showed:
- Default (1): 647 seconds total execution time
- Setting to 5: 181 seconds (72% faster)
- Setting to 10: 124 seconds (80% faster)

<!--- Link to issue you have raised -->

Fixes: #
https://github.com/tinkerbell/rufio/issues/311

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
